### PR TITLE
get global-setup working with jest in an nx workspace

### DIFF
--- a/packages/some-test-lib/jest.config.ts
+++ b/packages/some-test-lib/jest.config.ts
@@ -10,6 +10,7 @@ export default {
   displayName: 'some-test-lib',
   preset: '../../jest.preset.js',
   transform: {
+    'jest-global-setup.ts': 'ts-jest',
     '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],


### PR DESCRIPTION
the global setup has to be transformed with ts-jest as it seems swc/jest isn't having the paths correctly registers
I even tried with @swc-node/register and still unable to have the paths correctly registered.

You can force to only transform the setup/teardown files with an extra entry in the transformers of the project.
This does mean that you'll have to duplicate the transformer setup in each jest project that uses the setup/teardown files unfornntually as it seems like the root level jest.preset.js does not merge the transformers option.

There might be a workaround by not using the nx register function, but unsure since that just uses ts-node and swc-node/register under the hood.

Ref: nrwl/nx#13345